### PR TITLE
thermal: fix pwm-fan thermal binding and add cooling maps

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-dg-tn3568.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-dg-tn3568.dts
@@ -125,19 +125,13 @@
 
 	fan: pwm-fan {
 		compatible = "pwm-fan";
+		#cooling-cells = <2>;
 		pwms = <&pwm12 0 40000 0>;
 		fan-supply = <&dc_12v>;
 		//interrupt-parent = <&gpio0>;
 		//interrupts = <20 IRQ_TYPE_EDGE_FALLING>;
-		pulses-per-revolution = <2>;
-        cooling-levels = <0 50 100 150 200 255>;
-        rockchip,temp-trips = <
-                40000   1
-                50000   2
-                55000   3
-                60000   4
-                70000   5
-        >;
+		//pulses-per-revolution = <2>;
+		cooling-levels = <0 50 100 150 200 255>;
 	};
 };
 
@@ -169,6 +163,50 @@
 
 &cpu3 {
 	cpu-supply = <&vdd_cpu>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_low: cpu-low {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu_warm: cpu-warm {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu_hot: cpu-hot {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu_hall: cpu-hall {
+			temperature = <80000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&cpu_low>;
+			cooling-device = <&fan 0 1>;
+		};
+		map1 {
+			trip = <&cpu_warm>;
+			cooling-device = <&fan 1 2>;
+		};
+		map2 {
+			trip = <&cpu_hot>;
+			cooling-device = <&fan 2 4>;
+		};
+		map3 {
+			trip = <&cpu_hall>;
+			cooling-device = <&fan 4 5>;
+		};
+	};
 };
 
 &gmac0 {


### PR DESCRIPTION
- Add missing #cooling-cells property to pwm-fan node
- Replace rockchip,temp-trips with standard thermal configuration
- Define temperature trips at 50°C, 60°C, 70°C, 80°C with corresponding fan levels
- Enable automatic fan speed control based on CPU temperature

Fixes fan running at full speed regardless of temperature.